### PR TITLE
remove help link as is causing layout to go to landscape on iPhone 7

### DIFF
--- a/speculaas/README.kops.md
+++ b/speculaas/README.kops.md
@@ -191,10 +191,10 @@ Use docker hub and switch to speculaas-kops context:
 ## Build and push
 
     docker build -t houseofmoran/speculaas-pieces-finder:11 ./pieces-finder
-    docker build -t houseofmoran/speculaas-pieces-view:29 ./pieces-view
+    docker build -t houseofmoran/speculaas-pieces-view:30 ./pieces-view
     
     docker push houseofmoran/speculaas-pieces-finder:11
-    docker push houseofmoran/speculaas-pieces-view:29
+    docker push houseofmoran/speculaas-pieces-view:30
         
 ## Deployments
 

--- a/speculaas/README.minikube.md
+++ b/speculaas/README.minikube.md
@@ -19,7 +19,7 @@ Use minikube docker registry and switch to speculaas context:
 ## Build
 
     docker build -t houseofmoran/speculaas-pieces-finder:11 ./pieces-finder
-    docker build -t houseofmoran/speculaas-pieces-view:29 ./pieces-view
+    docker build -t houseofmoran/speculaas-pieces-view:30 ./pieces-view
     
 ## Startup
 

--- a/speculaas/pieces-view/k8s/deployment.yaml
+++ b/speculaas/pieces-view/k8s/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pieces-view
-        image: houseofmoran/speculaas-pieces-view:29
+        image: houseofmoran/speculaas-pieces-view:30
         resources:
           limits:
             cpu: 100m

--- a/speculaas/pieces-view/src/components/App.js
+++ b/speculaas/pieces-view/src/components/App.js
@@ -70,9 +70,6 @@ class App extends Component {
                         possibleChoices={this.state.possibleChoices}
                         chosenIds={this.state.chosenIds}
                         onChosen={this.handleChosen}/>
-          <div class="WhatIsThis">
-            <a href='https://github.com/mikemoraned/biscuits'>?</a>
-          </div>
         </div>
         <PlaceList transitionProportion={this.state.t}
                    possibleChoices={this.state.possibleChoices}


### PR DESCRIPTION
I don't know why, but adding the help link ("?") has made the main
canvas think it is displaying in landscape, so show city and bits
next to each other as opposed to above each other