### PR TITLE
optimise for speed instead of size

### DIFF
--- a/garibaldi/biscuiting-lib/Cargo.lock
+++ b/garibaldi/biscuiting-lib/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "biscuiting-lib"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/garibaldi/biscuiting-lib/Cargo.toml
+++ b/garibaldi/biscuiting-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuiting-lib"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 
@@ -22,9 +22,9 @@ console_error_panic_hook = "0.1"
 wee_alloc = { version="0.4", optional=true}
 
 [features]
-default = ["wee_alloc"]
+# default = ["wee_alloc"]
 
 [profile.release]
 lto = true
-opt-level = 's'
+opt-level = 3
 debug = true

--- a/garibaldi/biscuiting-lib/src/lib.rs
+++ b/garibaldi/biscuiting-lib/src/lib.rs
@@ -3,6 +3,7 @@ extern crate console_error_panic_hook;
 extern crate image;
 extern crate js_sys;
 extern crate wasm_bindgen;
+#[cfg(feature = "wee_alloc")]
 extern crate wee_alloc;
 
 use wasm_bindgen::prelude::*;

--- a/garibaldi/wasm-biscuits-frontend/package.json
+++ b/garibaldi/wasm-biscuits-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@mike_moran/biscuiting-lib": "^0.6.1",
+    "@mike_moran/biscuiting-lib": "^0.6.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-scripts": "3.1.1"


### PR DESCRIPTION
- disable wee_alloc; with it enabled, render times
  in Chrome were around 300ms, but without, around
  30ms
- also set `opt-level` to `3`